### PR TITLE
Allow the user to see the correct notice message

### DIFF
--- a/app/controllers/spree/admin/gdpr_requests_controller.rb
+++ b/app/controllers/spree/admin/gdpr_requests_controller.rb
@@ -19,7 +19,7 @@ module Spree
         end
 
         @object.serve
-        redirect_to admin_gdpr_requests_path, notice: t('gdpr.exports.scheduled')
+        redirect_to admin_gdpr_requests_path, notice: t("gdpr.exports.#{@object.intent}")
       end
 
       private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,10 @@
 en:
   gdpr:
     exports:
-      scheduled: The data export will be emailed to the user shortly.
+      data_restriction: The data restriction is now enabled.
+      data_erasure: The data has been deleted.
+      data_export: The data export will be emailed to the user shortly.
+      resume_processing: The data restriction is now disabled.
       error: There was an error serving the request.
   spree:
     new_gdpr_request: New GDPR request


### PR DESCRIPTION
Ref: #7 

Allow the user to see the correct notice message when a request is served

![2019-09-12 12 14 19](https://user-images.githubusercontent.com/9986708/64775664-f375d400-d556-11e9-8ae0-2b2bbd82be43.gif)
