### PR TITLE
Add `after_create` and `after_serve` hooks  

### DIFF
--- a/app/models/spree/gdpr_request.rb
+++ b/app/models/spree/gdpr_request.rb
@@ -14,6 +14,8 @@ module Spree
     validates :intent, presence: true
     validates :user, presence: true
 
+    after_create :after_create
+
     def serve
       result = case intent.to_sym
       when :data_export
@@ -33,7 +35,22 @@ module Spree
         processed_segments: [result],
       )
 
+      after_serve
       result
+    end
+
+    private
+
+    def after_create
+      Spree::Event.fire 'gdpr_request_created' if defined? Spree::Event
+
+      # otherwise noop, overwrite me in your app
+    end
+
+    def after_serve
+      Spree::Event.fire 'gdpr_request_served' if defined? Spree::Event
+
+      # otherwise noop, overwrite me in your app
     end
   end
 end

--- a/spec/models/spree/gdpr_request_spec.rb
+++ b/spec/models/spree/gdpr_request_spec.rb
@@ -9,8 +9,36 @@ RSpec.describe Spree::GdprRequest do
     expect(gdpr_request).to be_valid
   end
 
+  # rubocop:disable SubjectStub
+  describe '#create' do
+    subject(:gdpr_request) { described_class.new(user: user, intent: :data_restriction) }
+
+    let(:user) { create(:user) }
+
+    before { allow(gdpr_request).to receive(:after_create) }
+
+    it 'calls after_create hook' do
+      gdpr_request.save!
+
+      expect(gdpr_request).to have_received(:after_create)
+    end
+  end
+  # rubocop:enable SubjectStub
+
   describe '#serve' do
     subject(:gdpr_request) { create(:gdpr_request, intent: intent) }
+
+    let(:intent) { :data_restriction }
+
+    # rubocop:disable SubjectStub
+    before { allow(gdpr_request).to receive(:after_serve) }
+
+    it 'calls after_serve hook' do
+      gdpr_request.serve
+
+      expect(gdpr_request).to have_received(:after_serve)
+    end
+    # rubocop:enable SubjectStub
 
     context 'when the request is for a data export' do
       let(:intent) { :data_export }
@@ -53,8 +81,6 @@ RSpec.describe Spree::GdprRequest do
     end
 
     context 'when the request is for a data restriction' do
-      let(:intent) { :data_restriction }
-
       let(:data_exporter) { instance_double('SolidusGdpr::DataRestrictor', run: %w[foo bar]) }
 
       before do


### PR DESCRIPTION
When a request is created or served, the `after_create` and `after_serve` hooks are called.
Each the hooks are called only if the request went ok.

Since in [Solidus 2.9](https://github.com/solidusio/solidus/blob/master/CHANGELOG.md#major-changes) is added the `Spree::Event` class to emit events, to use the hooks you can:

- Override the `after_create` and `after_serve` methods if your application has Solidus < 2.9
- Subscribe the events if your application has Solidus >= 2.9, here the documentation: https://guides.solidus.io/developers/events/overview.html#events