### PR TITLE
Fix tests and allow support for extension to be used on Solidus 3

### DIFF
--- a/lib/solidus_gdpr/serializers/address_serializer.rb
+++ b/lib/solidus_gdpr/serializers/address_serializer.rb
@@ -37,7 +37,7 @@ module SolidusGdpr
       private
 
       def name_attributes
-        if ::Spree::Config.has_preference?(:use_combined_first_and_last_name_in_address) && ::Spree::Config.use_combined_first_and_last_name_in_address
+        if SolidusSupport.combined_first_and_last_name_in_address?
           {
             name: object.name
           }

--- a/solidus_gdpr.gemspec
+++ b/solidus_gdpr.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rubyzip', ['>= 1.2', '< 3.0']
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  s.add_dependency 'solidus_support', '~> 0.5'
+  s.add_dependency 'solidus_support', '~> 0.8'
 
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'sass-rails'

--- a/solidus_gdpr.gemspec
+++ b/solidus_gdpr.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   if s.respond_to?(:metadata)
     s.metadata["homepage_uri"] = s.homepage if s.homepage
-    s.metadata["source_code_uri"] = s.homepage if s.homepage
+    s.metadata["source_code_uri"] = "https://github.com/solidusio-contrib/solidus_gdpr"
     s.metadata["changelog_uri"] = 'https://github.com/solidusio-contrib/solidus_gdpr/blob/master/CHANGELOG.md'
   end
 

--- a/spec/solidus_gdpr/serializers/address_serializer_spec.rb
+++ b/spec/solidus_gdpr/serializers/address_serializer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SolidusGdpr::Serializers::AddressSerializer do
 
   describe '#as_json' do
     it 'matches the snapshot' do
-      if ::Spree::Config.has_preference?(:use_combined_first_and_last_name_in_address) && ::Spree::Config.use_combined_first_and_last_name_in_address
+      if SolidusSupport.combined_first_and_last_name_in_address?
         expect(prepare_for_snapshot(serializer)).to match_snapshot('serializers/address_serializer')
       else
         expect(prepare_for_snapshot(serializer)).to match_snapshot('serializers/legacy_address_serializer')

--- a/spec/solidus_gdpr/serializers/order_serializer_spec.rb
+++ b/spec/solidus_gdpr/serializers/order_serializer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SolidusGdpr::Serializers::OrderSerializer do
 
   describe '#as_json' do
     it 'matches the snapshot' do
-      if ::Spree::Config.has_preference?(:use_combined_first_and_last_name_in_address) && ::Spree::Config.use_combined_first_and_last_name_in_address
+      if SolidusSupport.combined_first_and_last_name_in_address?
         expect(prepare_for_snapshot(serializer)).to match_snapshot('serializers/order_serializer')
       else
         expect(prepare_for_snapshot(serializer)).to match_snapshot('serializers/legacy_order_serializer')


### PR DESCRIPTION
This change will get the build passing all the way up to `master`. 

The only change required was to use the `combined_first_and_last_name_in_address?` helper from `SolidusSupport` for which we needed to bump the version of that gem to `0.8`. Using this helper should preserve backwards compatibility for this extension from `2.9` to current `master` for the name change in core (See solidusio/solidus#3458).

Closes #35 