### PR TITLE
Add Solidus 3.4 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   # run specs against Solidus supported versions only without the need
   # to change this configuration every time a Solidus version is released
   # or goes EOL.
-  solidusio_extensions: solidusio/extensions@volatile
+  solidusio_extensions: solidusio/extensions@0.7.3
 
   browser-tools: circleci/browser-tools@1.1
 
@@ -26,14 +26,14 @@ workflows:
     jobs:
       - run-specs-with-postgres
       - run-specs-with-mysql
-  "Weekly run specs against master":
+  "Weekly run specs against main":
     triggers:
       - schedule:
           cron: "0 0 * * 4" # every Thursday
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - run-specs-with-postgres
       - run-specs-with-mysql

--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,9 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-solidus_git, solidus_frontend_git = if (branch == 'master') || (branch >= 'v3.2')
-                                      %w[solidusio/solidus solidusio/solidus_frontend]
-                                    else
-                                      %w[solidusio/solidus] * 2
-                                    end
-gem 'solidus', github: solidus_git, branch: branch
-gem 'solidus_frontend', github: solidus_frontend_git, branch: branch
+branch = ENV.fetch('SOLIDUS_BRANCH', 'v3.4')
+gem 'solidus', github: "solidusio/solidus", branch: branch
+gem 'solidus_frontend', github: "solidusio/solidus_frontend", branch: branch
 
 # Needed to help Bundler figure out how to resolve dependencies,
 # otherwise it takes forever to resolve them.

--- a/solidus_gdpr.gemspec
+++ b/solidus_gdpr.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   if s.respond_to?(:metadata)
     s.metadata["homepage_uri"] = s.homepage if s.homepage
     s.metadata["source_code_uri"] = "https://github.com/solidusio-contrib/solidus_gdpr"
-    s.metadata["changelog_uri"] = 'https://github.com/solidusio-contrib/solidus_gdpr/blob/master/CHANGELOG.md'
+    s.metadata["changelog_uri"] = 'https://github.com/solidusio-contrib/solidus_gdpr/blob/main/CHANGELOG.md'
   end
 
   s.required_ruby_version = '>= 2.4'

--- a/solidus_gdpr.gemspec
+++ b/solidus_gdpr.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
 
   s.add_dependency 'rubyzip', ['>= 1.2', '< 3.0']
-  s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
+  s.add_dependency 'solidus_core', ['>= 3.4.0', '< 4']
   s.add_dependency 'solidus_support', '~> 0.9'
 
   s.add_development_dependency 'coffee-rails'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,9 @@ require File.expand_path('dummy/config/environment.rb', __dir__)
 # Requires factories and other useful helpers defined in spree_core.
 require 'solidus_dev_support/rspec/feature_helper'
 
+require "spree/testing_support/factory_bot"
+Spree::TestingSupport::FactoryBot.add_paths_and_load!
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }


### PR DESCRIPTION
We stay below 4.0 and require at least 3.4 to make upgrading to v4.0 easier